### PR TITLE
build(deps): bump various dependencies

### DIFF
--- a/annotation/build.gradle.kts
+++ b/annotation/build.gradle.kts
@@ -1,4 +1,3 @@
-import com.vanniktech.maven.publish.SonatypeHost
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import java.net.URI
 
@@ -33,7 +32,7 @@ publishing {
 }
 
 mavenPublishing {
-    publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL)
+    publishToMavenCentral()
     signAllPublications()
 
     coordinates(

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,17 +1,17 @@
 [versions]
-agp = "8.9.0"
-kotlin = "2.1.20"
-coreKtx = "1.15.0"
+agp = "8.11.0"
+kotlin = "2.2.0"
+coreKtx = "1.16.0"
 junit = "4.13.2"
 junitVersion = "1.2.1"
 espressoCore = "3.6.1"
-ksp-test = "0.7.0"
-lifecycleRuntimeKtx = "2.8.7"
+ksp-test = "0.8.0"
+lifecycleRuntimeKtx = "2.9.1"
 activityCompose = "1.10.1"
-composeBom = "2025.03.00"
-jetbrainsKotlinJvm = "2.1.20"
-kspVersion = "2.1.20-1.0.31"
-mavenPublish = "0.31.0"
+composeBom = "2025.06.01"
+jetbrainsKotlinJvm = "2.2.0"
+kspVersion = "2.2.0-2.0.2"
+mavenPublish = "0.33.0"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sun Dec 29 21:38:20 AEDT 2024
+#Thu Jul 10 22:34:39 AEST 2025
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/processor/build.gradle.kts
+++ b/processor/build.gradle.kts
@@ -1,4 +1,3 @@
-import com.vanniktech.maven.publish.SonatypeHost
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import java.net.URI
 
@@ -41,7 +40,7 @@ publishing {
 }
 
 mavenPublishing {
-    publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL)
+    publishToMavenCentral()
     signAllPublications()
     coordinates(
         groupId = "biz.aydin.library.uistate-extension",


### PR DESCRIPTION
Bumps several dependencies to their latest versions.

Notable updates include:
- Android Gradle Plugin (AGP) from 8.9.0 to 8.11.0
- Kotlin from 2.1.20 to 2.2.0
- Core KTX from 1.15.0 to 1.16.0
- KSP Test from 0.7.0 to 0.8.0
- Lifecycle Runtime KTX from 2.8.7 to 2.9.1
- Compose BOM from 2025.03.00 to 2025.06.01
- KSP from 2.1.20-1.0.31 to 2.2.0-2.0.2
- Maven Publish from 0.31.0 to 0.33.0
- Gradle Wrapper from 8.11.1 to 8.14.3

Additionally, `SonatypeHost.CENTRAL_PORTAL` is removed from `publishToMavenCentral` calls as it's now the default.

---
updated-dependencies:
- dependency-name: com.android.application dependency-version: 8.11.0 dependency-type: direct:production update-type: version-update:semver-minor
- dependency-name: org.jetbrains.kotlin.android dependency-version: 2.2.0 dependency-type: direct:production update-type: version-update:semver-minor
- dependency-name: androidx.core:core-ktx dependency-version: 1.16.0 dependency-type: direct:production update-type: version-update:semver-minor
- dependency-name: com.github.aydinmustafa.ksp-test dependency-version: 0.8.0 dependency-type: direct:production update-type: version-update:semver-minor
- dependency-name: androidx.lifecycle:lifecycle-runtime-ktx dependency-version: 2.9.1 dependency-type: direct:production update-type: version-update:semver-minor
- dependency-name: androidx.compose:compose-bom dependency-version: 2025.06.01 dependency-type: direct:production
- dependency-name: org.jetbrains.kotlin.jvm dependency-version: 2.2.0 dependency-type: direct:production update-type: version-update:semver-minor
- dependency-name: com.google.devtools.ksp dependency-version: 2.2.0-2.0.2 dependency-type: direct:production
- dependency-name: com.vanniktech.maven.publish dependency-version: 0.33.0 dependency-type: direct:production update-type: version-update:semver-minor
- dependency-name: gradle dependency-version: 8.14.3 dependency-type: direct:production update-type: version-update:semver-minor ...