### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -1,5 +1,8 @@
 name: PR Check
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/umitnuri/uistate-extensions/security/code-scanning/1](https://github.com/umitnuri/uistate-extensions/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow. Since the workflow only performs build and test operations, it likely only requires read access to the repository contents. We will add the `permissions` block at the root level of the workflow to apply it to all jobs. This ensures that the `GITHUB_TOKEN` used by the workflow has the minimal permissions required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
