### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - main
+permissions:
+  contents: read
 jobs:
   Build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/umitnuri/uistate-extensions/security/code-scanning/2](https://github.com/umitnuri/uistate-extensions/security/code-scanning/2)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will specify the least privileges required for the workflow to function correctly. Based on the provided workflow, it primarily checks out the repository and builds the code, so it only needs `contents: read` permission. This ensures that the workflow adheres to the principle of least privilege.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
