### PR TITLE
build(deps): bump various dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,4 +8,4 @@ updates:
   - package-ecosystem: "gradle" # See documentation for possible values
     directory: "/" # Location of package manifests
     schedule:
-      interval: "weekly"
+      interval: "monthly"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,12 +12,6 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
-      - name: set up JDK 17
-        uses: actions/setup-java@v3
-        with:
-          java-version: '17'
-          distribution: 'temurin'
-
       - name: 🏗️ Build, Test
         run: |
           ./gradlew clean build

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -13,12 +13,6 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
-      - name: set up JDK 17
-        uses: actions/setup-java@v3
-        with:
-          java-version: '17'
-          distribution: 'temurin'
-
       - name: 🏗️ Build, Test
         run: |
           ./gradlew clean build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,11 +11,6 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
-      - name: set up JDK 17
-        uses: actions/setup-java@v3
-        with:
-          java-version: '17'
-          distribution: 'temurin'
       - id: get_version_from_tag
         name: Get version
         uses: jannemattila/get-version-from-tag@v4

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
 plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.android)
@@ -32,11 +34,13 @@ android {
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17
     }
-    kotlinOptions {
-        jvmTarget = "17"
-    }
     buildFeatures {
         compose = true
+    }
+    kotlin {
+        compilerOptions {
+            jvmTarget.set(JvmTarget.JVM_17)
+        }
     }
 }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,17 +1,17 @@
 [versions]
-agp = "8.11.0"
+agp = "8.12.0"
 kotlin = "2.2.0"
 coreKtx = "1.16.0"
 junit = "4.13.2"
-junitVersion = "1.2.1"
-espressoCore = "3.6.1"
+junitVersion = "1.3.0"
+espressoCore = "3.7.0"
 ksp-test = "0.8.0"
-lifecycleRuntimeKtx = "2.9.1"
+lifecycleRuntimeKtx = "2.9.2"
 activityCompose = "1.10.1"
-composeBom = "2025.06.01"
+composeBom = "2025.07.00"
 jetbrainsKotlinJvm = "2.2.0"
 kspVersion = "2.2.0-2.0.2"
-mavenPublish = "0.33.0"
+mavenPublish = "0.34.0"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }


### PR DESCRIPTION
Bumps several dependencies to their latest versions.

Notable updates include:
- Android Gradle Plugin (AGP) from 8.11.0 to 8.12.0
- JUnit Version from 1.2.1 to 1.3.0
- Espresso Core from 3.6.1 to 3.7.0
- Lifecycle Runtime KTX from 2.9.1 to 2.9.2
- Compose BOM from 2025.06.01 to 2025.07.00
- Maven Publish from 0.33.0 to 0.34.0

Additionally, JDK setup is removed from the PR check workflow as it is no longer necessary.

---
updated-dependencies:
- dependency-name: com.android.application dependency-version: 8.12.0 dependency-type: direct:production update-type: version-update:semver-minor
- dependency-name: androidx.test.ext:junit dependency-version: 1.3.0 dependency-type: direct:production update-type: version-update:semver-minor
- dependency-name: androidx.test.espresso:espresso-core dependency-version: 3.7.0 dependency-type: direct:production update-type: version-update:semver-minor
- dependency-name: androidx.lifecycle:lifecycle-runtime-ktx dependency-version: 2.9.2 dependency-type: direct:production update-type: version-update:semver-patch
- dependency-name: androidx.compose:compose-bom dependency-version: 2025.07.00 dependency-type: direct:production
- dependency-name: com.vanniktech.maven.publish dependency-version: 0.34.0 dependency-type: direct:production update-type: version-update:semver-minor ...